### PR TITLE
bump Hadolint to v1.17.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # hadolint ignore=DL3007
 FROM alpine:latest
 
-LABEL version="1.4.0"
+LABEL version="1.5.0"
 LABEL name="hadolint-action"
 LABEL repository="http://github.com/burdzwastaken/hadolint-action"
 LABEL homepage="http://github.com/burdzwastaken/hadolint-action"
@@ -20,7 +20,7 @@ RUN apk add --no-cache \
         curl \
         jq
 
-ENV HADOLINT_VERSION 1.17.2
+ENV HADOLINT_VERSION 1.17.3
 RUN curl -fsSL -o /usr/bin/hadolint "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-x86_64" && \
         chmod +x /usr/bin/hadolint
 


### PR DESCRIPTION
ref: https://github.com/hadolint/hadolint/releases/tag/v1.17.3