### PR TITLE
bump Hadolint to v1.18.0, hadolint-action to v1.9.0 & include a note about inline-ignores

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # hadolint ignore=DL3007
 FROM alpine:latest
 
-LABEL version="1.8.1"
+LABEL version="1.9.0"
 LABEL name="hadolint-action"
 LABEL repository="http://github.com/burdzwastaken/hadolint-action"
 LABEL homepage="http://github.com/burdzwastaken/hadolint-action"
-LABEL hadolint_version="v1.17.7"
+LABEL hadolint_version="v1.18.0"
 LABEL maintainer="Matt Burdan <github@burdz.net>"
 
 LABEL "com.github.actions.name"="hadolint"
@@ -21,7 +21,7 @@ RUN apk add --no-cache \
         curl \
         jq
 
-ENV HADOLINT_VERSION 1.17.7
+ENV HADOLINT_VERSION 1.18.0
 RUN curl -fsSL -o /usr/bin/hadolint "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-x86_64" && \
         chmod +x /usr/bin/hadolint
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ Name | Default | Description
 
 ![demo](images/hadolint-action.png)
 
+## FAQ
+* How can I ignore rules as this action does not (yet) support supplying a
+  configuration file?
+  * You can utilize
+	[inline-ignores](https://github.com/hadolint/hadolint#inline-ignores) within
+	your `Dockerfile`
+
 ## TODO
 * Let users supply their own `hadolint.yaml` and/or trusted registries passed through
 * Multiple `Dockerfile` support


### PR DESCRIPTION
ref: https://github.com/hadolint/hadolint/releases/tag/v1.18.0

also closes #20