### PR TITLE
Bump hadolint to v1.19.0 & hadolint-action to v1.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # hadolint ignore=DL3007
 FROM alpine:latest
 
-ENV HADOLINT_VERSION 1.18.2
+ENV HADOLINT_VERSION 1.19.0
 
-LABEL version="1.9.1"
+LABEL version="1.10.0"
 LABEL name="hadolint-action"
 LABEL repository="https://github.com/burdzwastaken/hadolint-action"
 LABEL homepage="https://github.com/burdzwastaken/hadolint-action"


### PR DESCRIPTION
ref: https://github.com/hadolint/hadolint/releases/tag/v1.19.0